### PR TITLE
Date formatting was not obeying the 'format' option for datepicker

### DIFF
--- a/jquery.datepair.js
+++ b/jquery.datepair.js
@@ -55,7 +55,8 @@ requires jQuery 1.7+
 				settings = _parseSettings(settings);
 
 				self.data('datepair-settings', settings);
-				self.on('change.datepair', null, _inputChanged);
+				self.on('changeDate.datepair', null, _inputChanged);
+				self.on('changeTime.datepair', null, _inputChanged);
 
 				// initialize datepair-datedelta and datepair-timedelta
 			});


### PR DESCRIPTION
Date formatting was not working - only yyyy-mm-dd format (the default) was working previously.

This PR should fix that so it obeys the format from the datepicker() widget.

Also... now you no longer need the base.js file which had the Date.format function, and "parseDate" function which aren't really needed.  datepicker() has it's own date formatting stuff which should be enough.

Also, why bundle datepicker() in the base.js ?  Can't it be included via bower?  You're doing that for the timepicker...
