### PR TITLE
Fix indentation in jQuery UI Datepicker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $('#some-container').datepair({
         return utc && new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
     },
     updateDate: function (el, v) {
-	var utc = new Date();
+        var utc = new Date();
         $(el).datepicker('setDate', new Date(v.getTime() - (utc.getTimezoneOffset() * 60000)));
     }
 });


### PR DESCRIPTION
Just replaced a tab with eight spaces to fix the indentation in the rendered document. Thanks for the great plugin!